### PR TITLE
Untrack pycache & pyinstaller files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# cache
+**/__pycache__
+*.pyc
+# PyInstaller
+build/
+dist/
+*.spec


### PR DESCRIPTION
This commit adds a ``.gitignore`` file.

[A `gitignore` file specifies intentionally untracked files that Git should ignore. Files already tracked by Git are not affected;](https://git-scm.com/docs/gitignore)
